### PR TITLE
Add workflow proposal - Flights 

### DIFF
--- a/engineering/workflow.md
+++ b/engineering/workflow.md
@@ -1,2 +1,8 @@
-### Retro 
-https://about.gitlab.com/handbook/engineering/management/group-retrospectives/
+# Project Management
+We follow a lightweight ceremoniless agile framework called [Flights](https://simonhoiberg.medium.com/the-flight-manual-9e1aedd04fbf).
+
+## Feedback 
+Feedback and opportunity areas should be shared continuously. Team members are also encouraged to share feedback at the conclusion of a flight.
+
+## Stand up
+We have daily async standups on discord facilitated by a discord bot. 

--- a/engineering/workflow.md
+++ b/engineering/workflow.md
@@ -1,0 +1,2 @@
+### Retro 
+https://about.gitlab.com/handbook/engineering/management/group-retrospectives/


### PR DESCRIPTION
Preread: https://about.gitlab.com/handbook/communication/#everything-starts-with-a-merge-request

I think traditional agile is too heavyweight for our team structure and goals. I propose following the model of [Flights](https://simonhoiberg.medium.com/the-flight-manual-9e1aedd04fbf).

For example - our current [story board](https://github.com/orgs/porter-finance/projects/4) would be our first flight - with @jordanalexandermeyer as the pilot and with an ETA landing date. 

Then after completing the onboarding we would likely have two flights in parallel - one around first iteration of smart contracts piloted by @Geczy and another one around the frontend/design work.

Please share thoughts & feedback. 